### PR TITLE
Add support for "Special" versions of moves

### DIFF
--- a/filetools.py
+++ b/filetools.py
@@ -32,32 +32,16 @@ def find_files_in_directory(loc, ext="") -> List[str] :
     else :
         return matching_files
 
-# fuck this
-def _find_gifify_handholding(loc) -> Tuple[List[str], List[str]] :
-    possible_png_paths = r"^char_[a-z]{2}_img$|^img$|^png$"
-    possible_png_re = re.compile(possible_png_paths)
-    possible_json_paths = r"^char_[a-z]{2}_col$|^col$|^json$"
-    possible_json_re = re.compile(possible_json_paths)
-
-    curdir = [f for f in os.listdir(loc)]
-    found_png = list(filter(possible_png_re.match, curdir))
-    found_json = list(filter(possible_json_re.match, curdir))
-
-    if len(found_png) == 0 or len(found_json) == 0 :
-        raise ValueError("Was not able to find png or json folders at the provided loc: %s.\n\tPlease check the usage guide." % loc)
-
-    png_files = find_files_in_directory(os.path.join(loc, found_png[0]), ".png")
-    json_files = find_files_in_directory(os.path.join(loc, found_json[0]), ".json")
-
-    print(png_files[0])
-    print(json_files[1])
-    pass
+def _find_T(loc, ext) -> List[str] :
+    files = find_files_in_directory(loc, ext)
+    files.sort(key=lambda x: int(x.split("_")[1].split(".")[0].split("ex")[0]))
+    return files
 
 def find_sprites(loc) -> List[str] :
-    return find_files_in_directory(loc, ".png")
+    return _find_T(loc, ".png")
 
 def find_collision(loc) -> List[str] :
-    return find_files_in_directory(loc, ".json")
+    return _find_T(loc, ".json")
 
 # link pngs to jsons
 # awful performance, I'm sure I can do better, but it's a non-issue right now.
@@ -65,7 +49,6 @@ def ensure_order(pngs: List[str], jsons: List[str]) -> Tuple[List[str], List[str
     out_png = []
     out_json = []
 
-    print(jsons)
     while len(pngs) > 0 :
         p = pngs.pop(0)
         pname = os.path.splitext(os.path.basename(p))[0]

--- a/filetools.py
+++ b/filetools.py
@@ -1,5 +1,4 @@
 import os
-import re
 from typing import List, Tuple
 
 def check_img_exists_and_png(loc) -> bool :

--- a/filetools.py
+++ b/filetools.py
@@ -65,12 +65,14 @@ def ensure_order(pngs: List[str], jsons: List[str]) -> Tuple[List[str], List[str
     out_png = []
     out_json = []
 
+    print(jsons)
     while len(pngs) > 0 :
         p = pngs.pop(0)
-        pname = os.path.splitext(p)[0]
+        pname = os.path.splitext(os.path.basename(p))[0]
         for i in range(0, len(jsons)) :
             j = jsons[i]
-            if pname == os.path.splitext(j)[0] :
+            json_name = os.path.splitext(os.path.basename(j))[0]
+            if pname == json_name or (pname + "01") == json_name :
                 out_png.append(p)
                 out_json.append(j)
                 break

--- a/gifify.py
+++ b/gifify.py
@@ -11,37 +11,6 @@ import filetools
 Bbox = Tuple[int, int, int, int]
 Relbox = Tuple[int, int, int, int]
 
-mode = "theyeet"
-
-if mode == "groundex" :
-    # 5b
-    images = ["tm201_0" + str(i) + ".png" for i in range(0,8)]
-    metadata = ["tm201_0" + str(i) + ".json" for i in range(0,8)]
-elif mode == "airex" :
-    # air dp
-    images = ["tm432_" + str(i) + ".png" for i in range(25,29)]
-    metadata = ["tm432_" + str(i) + ".json" for i in range(25,29)]
-elif mode == "airthrowex" :
-    # air throw
-    images = ["tm321_0" + str(i) + ".png" for i in range(2,7)]
-    metadata = ["tm321_0" + str(i) + ".json" for i in range(2,7)]
-elif mode =="backthrowex" :
-    # back throw
-    images = ["tm313_%s.png" % str(i).zfill(2) for i in range(0,14)]
-    metadata = ["tm313_%s.json" % str(i).zfill(2) for i in range(0,14)]
-elif mode =="theyeet" :
-    # 6c
-    images = ["tm213_%s.png" % str(i).zfill(2) for i in range(0,24)]
-    metadata = ["tm213_%s.json" % str(i).zfill(2) for i in range(0,24)]
-
-
-# # get palette + transparency
-# p, t = spriterecolor.get_palette_and_transparency("palette_ref.png")
-
-# # load images and then apply our palette
-# l_i = [Image.open(os.path.join(idirectory,i)) for i in images]
-# l_pi = [spriterecolor._apply_palette(i, p, t).convert("RGBA") for i in l_i]
-
 class Hurtbox() :
     w: int
     h: int
@@ -303,9 +272,7 @@ def compile_sprites(sprites: List[Sprite], hitboxes: bool = False) -> List[Image
     # iterate over sprites; add dur multiples of them in the list to imitate # of frames they are present
     output: List[Image.Image] = []
     for i,spr in enumerate(sprites):
-        img_l = [spr.img]
-        img_l = img_l * spr.duration
-        output.extend(img_l)
+        output.extend([spr.img] * spr.duration)
 
     return output
 
@@ -359,6 +326,8 @@ def _make_manual(names: List[str], images: List[Image.Image], durations: Union[L
 def _from_given_paths(pngpaths, jsonpaths, duration, hb, overwrite, output, oformat) :
     pngs = pngpaths
     jsons = jsonpaths
+    
+    pngs, jsons = filetools.ensure_order(pngs, jsons)
     duration = [int(duration)] * len(pngs)
     make_gif_from_sprlocs_collocs(pngs, jsons, duration, output, hb, overwrite, oformat)
 


### PR DESCRIPTION
Resolves #6 

Now when it checks for a `json` file associated with a `png`, it also checks if `{basename}01.png` exists, which seems to have resolved the problem.

(Context:
For an ex file, such as `tm030_03ex.png`, its associated json file is actually called `tm030_03ex01.png`.
If this doesn't work for another ex, my money is on that `01` being something else, and I need to make the file matching more robust.)